### PR TITLE
Add Health Attribute for Containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ monitor_docker:
 | images                            | Number of images                | -     |
 | state                             | Container state. This is created, restarting, running, removing, paused, exited or dead  | -     |
 | status                            | Container status. E.g. Up 13 days, Up 5 hours, Exited (0) 11 hours ago | -     |
+| health                            | Container health if available   | -     |
 | uptime                            | Container start time            | -     |
 | image                             | Container image                 | -     |
 | cpu_percentage                    | CPU usage                       | %     |

--- a/custom_components/monitor_docker/const.py
+++ b/custom_components/monitor_docker/const.py
@@ -62,7 +62,7 @@ DOCKER_MONITOR_LIST = {
 
 CONTAINER_MONITOR_LIST = {
     CONTAINER_INFO_STATE: ["State", None, "mdi:checkbox-marked-circle-outline", None],
-    CONTAINER_INFO_HEALTH: ["Health", None, "mdi:hearth-pulse", None],
+    CONTAINER_INFO_HEALTH: ["Health", None, "mdi:heart-pulse", None],
     CONTAINER_INFO_STATUS: ["Status", None, "mdi:checkbox-marked-circle-outline", None],
     CONTAINER_INFO_UPTIME: ["Up Time", "", "mdi:clock", "timestamp"],
     CONTAINER_INFO_IMAGE: ["Image", None, "mdi:information-outline", None],

--- a/custom_components/monitor_docker/const.py
+++ b/custom_components/monitor_docker/const.py
@@ -33,6 +33,7 @@ DOCKER_STATS_MEMORY_PERCENTAGE = "containers_memory_percentage"
 
 CONTAINER_INFO_ALLINONE = "allinone"
 CONTAINER_INFO_STATE = "state"
+CONTAINER_INFO_HEALTH = "health"
 CONTAINER_INFO_STATUS = "status"
 CONTAINER_INFO_NETWORK_AVAILABLE = "network_available"
 CONTAINER_INFO_UPTIME = "uptime"
@@ -61,6 +62,7 @@ DOCKER_MONITOR_LIST = {
 
 CONTAINER_MONITOR_LIST = {
     CONTAINER_INFO_STATE: ["State", None, "mdi:checkbox-marked-circle-outline", None],
+    CONTAINER_INFO_HEALTH: ["Health", None, "mdi:hearth-pulse", None],
     CONTAINER_INFO_STATUS: ["Status", None, "mdi:checkbox-marked-circle-outline", None],
     CONTAINER_INFO_UPTIME: ["Up Time", "", "mdi:clock", "timestamp"],
     CONTAINER_INFO_IMAGE: ["Image", None, "mdi:information-outline", None],

--- a/custom_components/monitor_docker/helpers.py
+++ b/custom_components/monitor_docker/helpers.py
@@ -42,6 +42,7 @@ from .const import (
     CONTAINER_STATS_NETWORK_TOTAL_DOWN,
     DOCKER_INFO_IMAGES,
     CONTAINER_INFO_STATE,
+    CONTAINER_INFO_HEALTH,
     CONTAINER_INFO_STATUS,
     CONTAINER_INFO_UPTIME,
     DOCKER_INFO_CONTAINER_RUNNING,
@@ -588,8 +589,9 @@ class DockerContainerAPI:
 
         raw = await self._container.show()
 
-        self._info[CONTAINER_INFO_STATE] = raw["State"]["Status"]
-        self._info[CONTAINER_INFO_IMAGE] = raw["Config"]["Image"]
+        self._info[CONTAINER_INFO_STATE]  = raw["State"]["Status"]
+        self._info[CONTAINER_INFO_HEALTH] = raw["State"]["Health"]["Status"]
+        self._info[CONTAINER_INFO_IMAGE]  = raw["Config"]["Image"]
         self._info[CONTAINER_INFO_NETWORK_AVAILABLE] = (
             False if raw["HostConfig"]["NetworkMode"] in ["host", "none"] else True
         )

--- a/custom_components/monitor_docker/helpers.py
+++ b/custom_components/monitor_docker/helpers.py
@@ -590,11 +590,15 @@ class DockerContainerAPI:
         raw = await self._container.show()
 
         self._info[CONTAINER_INFO_STATE]  = raw["State"]["Status"]
-        self._info[CONTAINER_INFO_HEALTH] = raw["State"]["Health"]["Status"]
         self._info[CONTAINER_INFO_IMAGE]  = raw["Config"]["Image"]
         self._info[CONTAINER_INFO_NETWORK_AVAILABLE] = (
             False if raw["HostConfig"]["NetworkMode"] in ["host", "none"] else True
         )
+
+        try:
+            self._info[CONTAINER_INFO_HEALTH] = raw["State"]["Health"]["Status"]
+        except:
+            self._info[CONTAINER_INFO_HEALTH] = "unknown"
 
         # We only do a calculation of startedAt, because we use it twice
         startedAt = parser.parse(raw["State"]["StartedAt"])

--- a/custom_components/monitor_docker/sensor.py
+++ b/custom_components/monitor_docker/sensor.py
@@ -27,6 +27,7 @@ from .const import (
     CONTAINER_INFO_IMAGE,
     CONTAINER_INFO_NETWORK_AVAILABLE,
     CONTAINER_INFO_STATE,
+    CONTAINER_INFO_HEALTH,
     CONTAINER_INFO_STATUS,
     CONTAINER_INFO_UPTIME,
     CONTAINER_MONITOR_LIST,
@@ -362,6 +363,7 @@ class DockerContainerSensor(Entity):
                     if cond in [
                         CONTAINER_INFO_STATUS,
                         CONTAINER_INFO_IMAGE,
+                        CONTAINER_INFO_HEALTH,
                         CONTAINER_INFO_UPTIME,
                     ]:
                         self._attributes[cond] = info.get(cond, None)
@@ -370,7 +372,7 @@ class DockerContainerSensor(Entity):
             elif self._var_id == CONTAINER_INFO_STATUS:
                 state = info.get(CONTAINER_INFO_STATUS)
                 self._state_extra = info.get(CONTAINER_INFO_STATE)
-            elif self._var_id in [CONTAINER_INFO_STATE, CONTAINER_INFO_IMAGE]:
+            elif self._var_id in [CONTAINER_INFO_STATE, CONTAINER_INFO_IMAGE, CONTAINER_INFO_HEALTH]:
                 state = info.get(self._var_id)
             elif info.get(CONTAINER_INFO_STATE) == "running":
                 if self._var_id in CONTAINER_MONITOR_LIST:

--- a/info.md
+++ b/info.md
@@ -102,6 +102,7 @@ monitor_docker:
 | images                            | Number of images                | -     |
 | state                             | Container state. This is created, restarting, running, removing, paused, exited or dead  | -     |
 | status                            | Container status. E.g. Up 13 days, Up 5 hours, Exited (0) 11 hours ago | -     |
+| health                            | Container health if available   | -     |
 | uptime                            | Container start time            | -     |
 | image                             | Container image                 | -     |
 | cpu_percentage                    | CPU usage                       | %     |


### PR DESCRIPTION
This PR adds the 'Health' state to containers. As monitored condition the option 'health' should be specified. It also supports the 'allinone' special condition, adding it as an attribute rather than a seperate sensor. If health is not available, 'unknown' will be the result.

Related feature request: #33 