### PR TITLE
Fix restart service to work with multiple docker hosts.

### DIFF
--- a/custom_components/monitor_docker/const.py
+++ b/custom_components/monitor_docker/const.py
@@ -103,6 +103,7 @@ MONITORED_CONDITIONS_LIST = list(DOCKER_MONITOR_LIST.keys()) + list(
 )
 
 ATTR_NAME = "name"
+ATTR_SERVER = "server"
 ATTR_MEMORY_LIMIT = "Memory_limit"
 ATTR_ONLINE_CPUS = "Online_CPUs"
 ATTR_VERSION_ARCH = "Architecture"

--- a/custom_components/monitor_docker/services.yaml
+++ b/custom_components/monitor_docker/services.yaml
@@ -4,3 +4,6 @@ restart:
     name:
       description: Name of the container
       example: "nodered"
+    server:
+      description: Name of the server, as given in config. Only required if you have more than one docker host config.
+      example: "mediaserver"

--- a/custom_components/monitor_docker/switch.py
+++ b/custom_components/monitor_docker/switch.py
@@ -36,13 +36,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
         cname = parm.data[ATTR_NAME]
         cserver = parm.data.get(ATTR_SERVER, None)
-        _LOGGER.error(
-            "Restart service input parameter, name: '%s' , server: '%s'", cname, cserver
-        )
 
         server_name = name
         if cserver is not None:
-
           if cserver not in hass.data[DOMAIN]:
             _LOGGER.error(
                 "Server '%s' is not configured",  cserver

--- a/custom_components/monitor_docker/switch.py
+++ b/custom_components/monitor_docker/switch.py
@@ -12,6 +12,7 @@ from homeassistant.util import slugify
 from .const import (
     API,
     ATTR_NAME,
+    ATTR_SERVER,
     CONF_CONTAINERS,
     CONF_RENAME,
     CONF_SWITCHENABLED,
@@ -23,7 +24,7 @@ from .const import (
     SERVICE_RESTART,
 )
 
-SERVICE_RESTART_SCHEMA = vol.Schema({ATTR_NAME: cv.string})
+SERVICE_RESTART_SCHEMA = vol.Schema({ATTR_NAME: cv.string, ATTR_SERVER: cv.string})
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,20 +35,36 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     async def async_restart(parm):
 
         cname = parm.data[ATTR_NAME]
-        if len(config[CONF_CONTAINERS]) == 0:
-            api = hass.data[DOMAIN][name][API]
-            if api.get_container(cname):
-                await api.get_container(cname).restart()
+        cserver = parm.data.get(ATTR_SERVER, None)
+        _LOGGER.error(
+            "Restart service input parameter, name: '%s' , server: '%s'", cname, cserver
+        )
+
+        server_name = name
+        if cserver is not None:
+
+          if cserver not in hass.data[DOMAIN]:
+            _LOGGER.error(
+                "Server '%s' is not configured",  cserver
+            )
+            return
+          else:
+            server_name = cserver
+
+        server_config = hass.data[DOMAIN][server_name][CONFIG]
+        server_api = hass.data[DOMAIN][server_name][API]
+
+        if len(server_config[CONF_CONTAINERS]) == 0:
+            if server_api.get_container(cname):
+                await server_api.get_container(cname).restart()
             else:
                 _LOGGER.error(
                     "Service restart failed, container '%s'does not exist", cname
                 )
-        elif cname in config[CONF_CONTAINERS]:
+        elif cname in server_config[CONF_CONTAINERS]:
             _LOGGER.debug("Trying to restart container '%s'", cname)
-
-            api = hass.data[DOMAIN][name][API]
-            if api.get_container(cname):
-                await api.get_container(cname).restart()
+            if server_api.get_container(cname):
+                await server_api.get_container(cname).restart()
             else:
                 _LOGGER.error(
                     "Service restart failed, container '%s'does not exist", cname


### PR DESCRIPTION
Added a new service parameter 'server' to specify host.  Not including this parameter should work as before, i.e. users with only one docker host specified will not be affected.