### PR TITLE
Make sensors available for statistics by adding state_class

### DIFF
--- a/custom_components/monitor_docker/const.py
+++ b/custom_components/monitor_docker/const.py
@@ -60,41 +60,43 @@ CONTAINER_STATS_NETWORK_TOTAL_UP = "network_total_up"
 CONTAINER_STATS_NETWORK_TOTAL_DOWN = "network_total_down"
 
 DOCKER_MONITOR_LIST = {
-    DOCKER_INFO_VERSION: ["Version", None, "mdi:information-outline", None],
-    DOCKER_INFO_CONTAINER_RUNNING: ["Containers Running", None, "mdi:docker", None],
-    DOCKER_INFO_CONTAINER_PAUSED: ["Containers Paused", None, "mdi:docker", None],
-    DOCKER_INFO_CONTAINER_STOPPED: ["Containers Stopped", None, "mdi:docker", None],
-    DOCKER_INFO_CONTAINER_TOTAL: ["Containers Total", None, "mdi:docker", None],
-    DOCKER_STATS_CPU_PERCENTAGE: ["CPU", "%", "mdi:chip", None],
-    DOCKER_STATS_1CPU_PERCENTAGE: ["1CPU", "%", "mdi:chip", None],
-    DOCKER_STATS_MEMORY: ["Memory", "MB", "mdi:memory", None],
-    DOCKER_STATS_MEMORY_PERCENTAGE: ["Memory (percent)", "%", "mdi:memory", None],
-    DOCKER_INFO_IMAGES: ["Images", None, "mdi:docker", None],
+    DOCKER_INFO_VERSION: ["Version", None, "mdi:information-outline", None, None],
+    DOCKER_INFO_CONTAINER_RUNNING: ["Containers Running", None, "mdi:docker", None, None],
+    DOCKER_INFO_CONTAINER_PAUSED: ["Containers Paused", None, "mdi:docker", None, None],
+    DOCKER_INFO_CONTAINER_STOPPED: ["Containers Stopped", None, "mdi:docker", None, None],
+    DOCKER_INFO_CONTAINER_TOTAL: ["Containers Total", None, "mdi:docker", None, None],
+    DOCKER_STATS_CPU_PERCENTAGE: ["CPU", "%", "mdi:chip", None, "measurement"],
+    DOCKER_STATS_1CPU_PERCENTAGE: ["1CPU", "%", "mdi:chip", None, "measurement"],
+    DOCKER_STATS_MEMORY: ["Memory", "MB", "mdi:memory", None, "measurement"],
+    DOCKER_STATS_MEMORY_PERCENTAGE: ["Memory (percent)", "%", "mdi:memory", None, "measurement"],
+    DOCKER_INFO_IMAGES: ["Images", None, "mdi:docker", None, None],
 }
 
 CONTAINER_MONITOR_LIST = {
-    CONTAINER_INFO_STATE: ["State", None, "mdi:checkbox-marked-circle-outline", None],
-    CONTAINER_INFO_HEALTH: ["Health", None, "mdi:heart-pulse", None],
-    CONTAINER_INFO_STATUS: ["Status", None, "mdi:checkbox-marked-circle-outline", None],
-    CONTAINER_INFO_UPTIME: ["Up Time", "", "mdi:clock", "timestamp"],
-    CONTAINER_INFO_IMAGE: ["Image", None, "mdi:information-outline", None],
-    CONTAINER_STATS_CPU_PERCENTAGE: ["CPU", "%", "mdi:chip", None],
-    CONTAINER_STATS_1CPU_PERCENTAGE: ["1CPU", "%", "mdi:chip", None],
-    CONTAINER_STATS_MEMORY: ["Memory", "MB", "mdi:memory", None],
-    CONTAINER_STATS_MEMORY_PERCENTAGE: ["Memory (percent)", "%", "mdi:memory", None],
-    CONTAINER_STATS_NETWORK_SPEED_UP: ["Network speed Up", "kB/s", "mdi:upload", None],
+    CONTAINER_INFO_STATE: ["State", None, "mdi:checkbox-marked-circle-outline", None, None],
+    CONTAINER_INFO_HEALTH: ["Health", None, "mdi:heart-pulse", None, None],
+    CONTAINER_INFO_STATUS: ["Status", None, "mdi:checkbox-marked-circle-outline", None, None],
+    CONTAINER_INFO_UPTIME: ["Up Time", "", "mdi:clock", "timestamp", None],
+    CONTAINER_INFO_IMAGE: ["Image", None, "mdi:information-outline", None, None],
+    CONTAINER_STATS_CPU_PERCENTAGE: ["CPU", "%", "mdi:chip", None, "measurement"],
+    CONTAINER_STATS_1CPU_PERCENTAGE: ["1CPU", "%", "mdi:chip", None, "measurement"],
+    CONTAINER_STATS_MEMORY: ["Memory", "MB", "mdi:memory", None, "measurement"],
+    CONTAINER_STATS_MEMORY_PERCENTAGE: ["Memory (percent)", "%", "mdi:memory", None, "measurement"],
+    CONTAINER_STATS_NETWORK_SPEED_UP: ["Network speed Up", "kB/s", "mdi:upload", None, "measurement"],
     CONTAINER_STATS_NETWORK_SPEED_DOWN: [
         "Network speed Down",
         "kB/s",
         "mdi:download",
         None,
+        "measurement"
     ],
-    CONTAINER_STATS_NETWORK_TOTAL_UP: ["Network total Up", "MB", "mdi:upload", None],
+    CONTAINER_STATS_NETWORK_TOTAL_UP: ["Network total Up", "MB", "mdi:upload", None, "total_increasing"],
     CONTAINER_STATS_NETWORK_TOTAL_DOWN: [
         "Network total Down",
         "MB",
         "mdi:download",
         None,
+        "total_increasing"
     ],
 }
 

--- a/custom_components/monitor_docker/sensor.py
+++ b/custom_components/monitor_docker/sensor.py
@@ -4,9 +4,8 @@ import asyncio
 import logging
 import re
 
-from homeassistant.components.sensor import ENTITY_ID_FORMAT
+from homeassistant.components.sensor import ENTITY_ID_FORMAT, SensorEntity
 from homeassistant.const import CONF_NAME, CONF_MONITORED_CONDITIONS
-from homeassistant.helpers.entity import Entity
 from homeassistant.util import slugify
 
 from .const import (
@@ -170,7 +169,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
 
 #################################################################
-class DockerSensor(Entity):
+class DockerSensor(SensorEntity):
     """Representation of a Docker Sensor."""
 
     def __init__(self, api, instance, prefix, variable):
@@ -277,7 +276,7 @@ class DockerSensor(Entity):
 
 
 #################################################################
-class DockerContainerSensor(Entity):
+class DockerContainerSensor(SensorEntity):
     """Representation of a Docker Sensor."""
 
     def __init__(

--- a/custom_components/monitor_docker/sensor.py
+++ b/custom_components/monitor_docker/sensor.py
@@ -186,6 +186,7 @@ class DockerSensor(Entity):
         self._var_unit = DOCKER_MONITOR_LIST[variable][1]
         self._var_icon = DOCKER_MONITOR_LIST[variable][2]
         self._var_class = DOCKER_MONITOR_LIST[variable][3]
+        self._var_state_class = DOCKER_MONITOR_LIST[variable][4]
 
         self._entity_id = ENTITY_ID_FORMAT.format(
             slugify(self._prefix + "_" + self._var_name)
@@ -224,6 +225,11 @@ class DockerSensor(Entity):
     def device_class(self):
         """Return the class of this sensor."""
         return self._var_class
+    
+    @property
+    def state_class(self):
+        """Return the state class of this sensor."""
+        return self._var_state_class
 
     @property
     def unit_of_measurement(self):
@@ -301,11 +307,13 @@ class DockerContainerSensor(Entity):
             self._var_unit = CONTAINER_MONITOR_LIST[CONTAINER_INFO_STATE][1]
             self._var_icon = CONTAINER_MONITOR_LIST[CONTAINER_INFO_STATE][2]
             self._var_class = CONTAINER_MONITOR_LIST[CONTAINER_INFO_STATE][3]
+            self._var_state_class = CONTAINER_MONITOR_LIST[CONTAINER_INFO_STATE][4]
         else:
             self._var_name = CONTAINER_MONITOR_LIST[variable][0]
             self._var_unit = CONTAINER_MONITOR_LIST[variable][1]
             self._var_icon = CONTAINER_MONITOR_LIST[variable][2]
             self._var_class = CONTAINER_MONITOR_LIST[variable][3]
+            self._var_state_class = CONTAINER_MONITOR_LIST[variable][4]
 
         self._state_extra = None
 
@@ -374,6 +382,11 @@ class DockerContainerSensor(Entity):
     def device_class(self):
         """Return the class of this sensor."""
         return self._var_class
+
+    @property
+    def state_class(self):
+        """Return the state class of this sensor."""
+        return self._var_state_class
 
     @property
     def unit_of_measurement(self):


### PR DESCRIPTION
This closes  #101 

- Updated consts to add state_class attributes for each condition
- Updated sensor.py so that sensors extend SensorEntity rather than the base Entity helper, giving access to state_class