### PR TITLE
Specific container switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,24 +106,24 @@ monitor_docker:
 
 #### Configuration variables
 
-| Parameter                   | Type                     | Description                                                           |
-| --------------------------- | ------------------------ | --------------------------------------------------------------------- |
-| name                        | string       (Required)  | Client name of Docker daemon. Defaults to `Docker`.                   |
-| url                         | string       (Optional)  | Host URL of Docker daemon. Defaults to `unix://var/run/docker.sock`. Remote Docker daemon via TCP socket is also supported, use e.g. `tcp://ip:2376`. Do NOT add a slash add the end, this will invalid the URL. For TLS support see Q&A section. SSH is not supported. |
-| scan_interval               | time_period  (Optional)  | Update interval. Defaults to 10 seconds.                              |
-| certpath                    | string       (Optional)  | If TCP socket is used, you can define your Docker certificate path, forcing Monitor Docker to enable TLS. The filenames must be `cert.pem` and `key.pem`|
-| containers                  | list         (Optional)  | Array of containers to monitor. Defaults to all containers.           |
-| containers_exclude          | list         (Optional)  | Array of containers to be excluded from monitoring, when all containrs are included. |
-| monitored_conditions        | list         (Optional)  | Array of conditions to be monitored. Defaults to all conditions.      |
-| rename                      | dictionary   (Optional)  | Dictionary of containers to rename. Default no renaming.              |
-| sensorname                  | string       (Optional)  | Sensor string to format the name used in Home Assistant. Defaults to `{name} {sensor}`, where `{name}` is the container name and `{sensor}` is e.g. Memory, Status, Network speed Up |
-| switchname                  | string       (Optional)  | Switch string to format the name used in Home Assistant. Defaults to `{name}`, where `{name}` is the container name. |
-| switchenabled               | boolean      (Optional)  | Enable/Disable the switch entity for all container (Default: enabled) |
-| precision_cpu               | integer      (Optional)  | Precision of CPU usage percentage (Default: 2) |
-| precision_memory_mb         | integer      (Optional)  | Precision of memory usage in MB (Default: 2) |
-| precision_memory_percentage | integer      (Optional)  | Precision of memory usage in percentage (Default: 2) |
-| precision_network_kb        | integer      (Optional)  | Precision of network bandwidth in kB (Default: 2) |
-| precision_network_mb        | integer      (Optional)  | Precision of network usage in MB (Default: 2) |
+| Parameter                   | Type                       | Description                                                           |
+| --------------------------- | -------------------------- | --------------------------------------------------------------------- |
+| name                        | string         (Required)  | Client name of Docker daemon. Defaults to `Docker`.                   |
+| url                         | string         (Optional)  | Host URL of Docker daemon. Defaults to `unix://var/run/docker.sock`. Remote Docker daemon via TCP socket is also supported, use e.g. `tcp://ip:2376`. Do NOT add a slash add the end, this will invalid the URL. For TLS support see Q&A section. SSH is not supported. |
+| scan_interval               | time_period    (Optional)  | Update interval. Defaults to 10 seconds.                              |
+| certpath                    | string         (Optional)  | If TCP socket is used, you can define your Docker certificate path, forcing Monitor Docker to enable TLS. The filenames must be `cert.pem` and `key.pem`|
+| containers                  | list           (Optional)  | Array of containers to monitor. Defaults to all containers.           |
+| containers_exclude          | list           (Optional)  | Array of containers to be excluded from monitoring, when all containers are included. |
+| monitored_conditions        | list           (Optional)  | Array of conditions to be monitored. Defaults to all conditions.      |
+| rename                      | dictionary     (Optional)  | Dictionary of containers to rename. Default no renaming.              |
+| sensorname                  | string         (Optional)  | Sensor string to format the name used in Home Assistant. Defaults to `{name} {sensor}`, where `{name}` is the container name and `{sensor}` is e.g. Memory, Status, Network speed Up |
+| switchname                  | string         (Optional)  | Switch string to format the name used in Home Assistant. Defaults to `{name}`, where `{name}` is the container name. |
+| switchenabled               | boolean / list (Optional)  | Enable/Disable the switch entity for containers (Default: `True` Enabled switch for all containers, `False`: Disabled switch for all containers). Or specify a list of containers for which to enable switch entities. |
+| precision_cpu               | integer        (Optional)  | Precision of CPU usage percentage (Default: 2) |
+| precision_memory_mb         | integer        (Optional)  | Precision of memory usage in MB (Default: 2) |
+| precision_memory_percentage | integer        (Optional)  | Precision of memory usage in percentage (Default: 2) |
+| precision_network_kb        | integer        (Optional)  | Precision of network bandwidth in kB (Default: 2) |
+| precision_network_mb        | integer        (Optional)  | Precision of network usage in MB (Default: 2) |
 
 | Monitored Conditions              | Description                     | Unit  |
 | --------------------------------- | ------------------------------- | ----- |

--- a/custom_components/monitor_docker/__init__.py
+++ b/custom_components/monitor_docker/__init__.py
@@ -67,7 +67,9 @@ DOCKER_SCHEMA = vol.Schema(
         vol.Optional(CONF_CONTAINERS_EXCLUDE, default=[]): cv.ensure_list,
         vol.Optional(CONF_RENAME, default={}): dict,
         vol.Optional(CONF_SENSORNAME, default=DEFAULT_SENSORNAME): cv.string,
-        vol.Optional(CONF_SWITCHENABLED, default=True): cv.boolean,
+        vol.Optional(CONF_SWITCHENABLED, default=True): vol.Any(
+            cv.boolean, cv.ensure_list(cv.string)
+        ),
         vol.Optional(CONF_SWITCHNAME, default=DEFAULT_SWITCHNAME): cv.string,
         vol.Optional(CONF_CERTPATH, default=""): cv.string,
         vol.Optional(CONF_RETRY, default=DEFAULT_RETRY): cv.positive_int,

--- a/custom_components/monitor_docker/switch.py
+++ b/custom_components/monitor_docker/switch.py
@@ -36,7 +36,6 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     """Set up the Monitor Docker Switch."""
 
     async def async_restart(parm):
-
         cname = parm.data[ATTR_NAME]
         cserver = parm.data.get(ATTR_SERVER, None)
 
@@ -72,7 +71,6 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             )
 
     def find_rename(d, item):
-
         for k in d:
             if re.match(k, item):
                 return d[k]
@@ -93,7 +91,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         prefix = config[CONF_PREFIX]
 
     # Don't create any switch if disabled
-    if not config[CONF_SWITCHENABLED]:
+    if config[CONF_SWITCHENABLED] == False:
         _LOGGER.debug("[%s]: Switch(es) are disabled", instance)
         return True
 
@@ -108,7 +106,6 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         clist = api.list_containers()
 
     for cname in clist:
-
         includeContainer = False
         if cname in config[CONF_CONTAINERS] or not config[CONF_CONTAINERS]:
             includeContainer = True
@@ -117,18 +114,23 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             includeContainer = False
 
         if includeContainer:
-            _LOGGER.debug("[%s] %s: Adding component Switch", instance, cname)
-
-            switches.append(
-                DockerContainerSwitch(
-                    api.get_container(cname),
-                    instance,
-                    prefix,
-                    cname,
-                    find_rename(config[CONF_RENAME], cname),
-                    config[CONF_SWITCHNAME],
+            if (
+                config[CONF_SWITCHENABLED] == True
+                or cname in config[CONF_SWITCHENABLED]
+            ):
+                _LOGGER.debug("[%s] %s: Adding component Switch", instance, cname)
+                switches.append(
+                    DockerContainerSwitch(
+                        api.get_container(cname),
+                        instance,
+                        prefix,
+                        cname,
+                        find_rename(config[CONF_RENAME], cname),
+                        config[CONF_SWITCHNAME],
+                    )
                 )
-            )
+            else:
+                _LOGGER.debug("[%s] %s: NOT Adding component Switch", instance, cname)
 
     if not switches:
         _LOGGER.info("[%s]: No containers set-up", instance)


### PR DESCRIPTION
This allows `switchenabled` to be provided with a list of container names. Containers included in this list will have their switches enabled and others will not have a switch entity.

Related issue: #113 