### PR TITLE
Report container image hash

### DIFF
--- a/custom_components/monitor_docker/const.py
+++ b/custom_components/monitor_docker/const.py
@@ -61,6 +61,7 @@ CONTAINER_INFO_STATUS = "status"
 CONTAINER_INFO_NETWORK_AVAILABLE = "network_available"
 CONTAINER_INFO_UPTIME = "uptime"
 CONTAINER_INFO_IMAGE = "image"
+CONTAINER_INFO_IMAGE_HASH = "image_hash"
 CONTAINER_STATS_CPU_PERCENTAGE = "cpu_percentage"
 CONTAINER_STATS_1CPU_PERCENTAGE = "1cpu_percentage"
 CONTAINER_STATS_MEMORY = "memory"
@@ -158,6 +159,11 @@ CONTAINER_MONITOR_LIST = {
         key=CONTAINER_INFO_IMAGE,
         name="Image",
         icon="mdi:information-outline",
+    ),
+    CONTAINER_INFO_IMAGE_HASH: SensorEntityDescription(
+        key=CONTAINER_INFO_IMAGE_HASH,
+        name="Image Hash",
+        icon="mdi:pound-box-outline",
     ),
     CONTAINER_STATS_CPU_PERCENTAGE: SensorEntityDescription(
         key=CONTAINER_STATS_CPU_PERCENTAGE,

--- a/custom_components/monitor_docker/helpers.py
+++ b/custom_components/monitor_docker/helpers.py
@@ -38,6 +38,7 @@ from .const import (
     CONTAINER,
     CONTAINER_INFO_HEALTH,
     CONTAINER_INFO_IMAGE,
+    CONTAINER_INFO_IMAGE_HASH,
     CONTAINER_INFO_NETWORK_AVAILABLE,
     CONTAINER_INFO_STATE,
     CONTAINER_INFO_STATUS,
@@ -835,6 +836,7 @@ class DockerContainerAPI:
 
         self._info[CONTAINER_INFO_STATE] = raw["State"]["Status"]
         self._info[CONTAINER_INFO_IMAGE] = raw["Config"]["Image"]
+        self._info[CONTAINER_INFO_IMAGE_HASH] = raw["Image"]
 
         if self._network_error <= 5:
             if CONTAINER_INFO_NETWORK_AVAILABLE not in self._info:

--- a/custom_components/monitor_docker/sensor.py
+++ b/custom_components/monitor_docker/sensor.py
@@ -36,6 +36,7 @@ from .const import (
     CONTAINER_INFO_ALLINONE,
     CONTAINER_INFO_HEALTH,
     CONTAINER_INFO_IMAGE,
+    CONTAINER_INFO_IMAGE_HASH,
     CONTAINER_INFO_NETWORK_AVAILABLE,
     CONTAINER_INFO_STATE,
     CONTAINER_INFO_STATUS,
@@ -440,6 +441,7 @@ class DockerContainerSensor(SensorEntity):
                     if cond in [
                         CONTAINER_INFO_STATUS,
                         CONTAINER_INFO_IMAGE,
+                        CONTAINER_INFO_IMAGE_HASH,
                         CONTAINER_INFO_HEALTH,
                         CONTAINER_INFO_UPTIME,
                     ]:
@@ -452,6 +454,7 @@ class DockerContainerSensor(SensorEntity):
             elif self.entity_description.key in [
                 CONTAINER_INFO_STATE,
                 CONTAINER_INFO_IMAGE,
+                CONTAINER_INFO_IMAGE_HASH,
                 CONTAINER_INFO_HEALTH,
             ]:
                 state = info.get(self.entity_description.key)


### PR DESCRIPTION
This reports the container's image hash, e.g. `sha256:d3c037890eb74d90117052da029213e4f9bdc88e2d3904157078a9b220840d0a` for Home Assistant 2024.12.3. This is useful for checking if the currently run image is the same as the latest one available in the repository.