### PR TITLE
Add Re-Authorization configuration step

### DIFF
--- a/custom_components/monitor_docker/helpers.py
+++ b/custom_components/monitor_docker/helpers.py
@@ -934,8 +934,6 @@ class DockerContainerAPI:
                     str(err),
                     exc_info=exc_info,
                 )
-                return  # For now do not activate Reauthentication flow
-                # https://developers.home-assistant.io/docs/config_entries_config_flow_handler#reauthentication
                 raise ConfigEntryAuthFailed(err) from err
 
             self._task = asyncio.create_task(self._run())


### PR DESCRIPTION
Part of #173 

If connection to Docker is lost it should enable a button "Reauthorize" or something in the HA Integrations page which should show the "user" step from normal set-up configurations but finalize on successful submit instead of go on with the Containers and Components steps.