### PR TITLE
Add import from configuration.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ NOTE: This is untested, use at your own risk!
 3. Select which Containers to monitor
 4. Select which Conditions to monitor for both the host and each Container
 
-For now all selections made during set-up will be frozen for that instance (is no reconfigure function implemented), meaning you have to remove and add the integration again to change settings.
-
 #### Manual
+
+> **IMPORTANT NOTICE!**: While manual configuration in `configuration.yaml` is still possible it will only be converted into a UI ConfigEntry upon first boot and after that ignored (while displaying a Repair issue to remove deprecaded onused config). It's recommended to setup the integration directly from UI using above process
 
 To use the `monitor_docker` in your installation, add the following to your `configuration.yaml` file:
 
@@ -183,7 +183,7 @@ logger:
 ### Q&A
 Here are some possible questions/errors with their answers.
 
-1. **Question:** Does this integration work with the HASS or supervisord installers?  
+1. **Question:** Does this integration work with the HASS or supervisord installers?
     **Answer:** Yes, with an external docker container. Home Assistant supervised does not expose the Docker UNIX/TCP socket. However, you can use an external docker container named `docker-socket-proxy`. Start this docker with the following docker-compose code. It exposes the socket over TCP and `monitor_docker` can listen to it.
     ```yaml
     # Proxy the Docker sock so that we can pick up stats for HomeAssistant
@@ -219,11 +219,11 @@ Here are some possible questions/errors with their answers.
       - name: Docker
         url: http://<host_ip>:2375
 ```
-2. **Error:** `Missing valid docker_host.Either DOCKER_HOST or local sockets are not available.`  
+2. **Error:** `Missing valid docker_host.Either DOCKER_HOST or local sockets are not available.`
     **Answer:** Most likely the socket is not mounted properly in your Home Assistant container. Please check if you added the volume `/var/run/docker.sock`
-3. **Error:** `aiodocker.exceptions.DockerError: DockerError(900, "Cannot connect to Docker Engine via http://10.0.0.1:2376...)`.  
+3. **Error:** `aiodocker.exceptions.DockerError: DockerError(900, "Cannot connect to Docker Engine via http://10.0.0.1:2376...)`.
     **Answer:** You are trying to connect via TCP and most likely the remote address is unavailable. Test it with the command `docker -H tcp://10.0.0.1:2376 ps` if it works (replace `10.0.0.1` with your IP address). Also you can consult the following URL for more help: https://docs.docker.com/config/daemon/remote-access/
-4. **Question:** Is Docker TCP socket via TLS supported?  
+4. **Question:** Is Docker TCP socket via TLS supported?
     **Answer:** Yes it is. You need to set the URL to e.g. `http://ip:2376` and the environment variables `DOCKER_TLS_VERIFY=1` and `DOCKER_CERT_PATH=<path to your certificates>` need to be set
 The following is a docker-compose example of how to set the environment variables and the volume with the certificates:
 ```
@@ -240,7 +240,7 @@ services:
       - DOCKER_CERT_PATH=/certs
 ...
 ```
-5. **Question:** Can this integration monitor 2 or more Docker instances?  
+5. **Question:** Can this integration monitor 2 or more Docker instances?
     **Answer:** Yes it can. Just duplicate the entries and give it an unique name and define the url as shown below:
 ```yaml
 # Example configuration.yaml entry
@@ -254,25 +254,25 @@ monitor_docker:
     ...
 ```
 *NOTE*: The integration supports multiple Docker instances, but you can only define 1 TLS configuration which is applied to all (thus you cannot mix TCP with and without TLS).
-6. **Question:** Can create, delete or re-create a container be implemented in the integration?  
+6. **Question:** Can create, delete or re-create a container be implemented in the integration?
     **Answer:** The used Docker library has no easy (and safe) way to handle such functionality. Please use *docker-compose* to handle such operations. If anybody can make this fully work in a safe way, I'll be happy to merge the PR
-7. **Question:** Can you add more security to a switch?  
+7. **Question:** Can you add more security to a switch?
     **Answer:** No, this isn't possible from the integration. You need to do this directly in Lovelace itself, within the card e.g. https://github.com/iantrich/restriction-card
-8. **Question:** All the reported memory values are 0 (zero), can this be fixed in the integration?  
+8. **Question:** All the reported memory values are 0 (zero), can this be fixed in the integration?
     **Answer:** No, the integration just uses the available information from the API and you should fix your Docker
-9. **Question:** Is it possible to monitor HASS.IO?  
+9. **Question:** Is it possible to monitor HASS.IO?
     **Answer:** Yes, please use the Docker Socker Proxy https://github.com/Tecnativa/docker-socket-proxy and configure http://ip:port to connect to the proxy. This has been tested and verified by other users, but I cannot give support on it.
-10. **Question:** I get a permission denied error?  
+10. **Question:** I get a permission denied error?
      **Answer:** In general Docker and HASS.IO are running as root and always can connect to /var/run/docker.sock. If you run in a venv environment or directly with Python, you may need to add the "docker" group to the user used for Home Assistant. The following commands may help you, and it is recommended to reboot after "usermod":
   ```
   $ sudo usermod -a -G docker <user>
   $ sudo reboot
   ```
-11. **Question:** Can you add the feature to check if there are updates to images in e.g. hub.docker.com?  
+11. **Question:** Can you add the feature to check if there are updates to images in e.g. hub.docker.com?
      **Answer:** Such feature goes outside of the scope of monitor_docker and there are few other options available for this. You can use https://newreleases.io or https://github.com/crazy-max/diun/
-12. **Question:** Is Docker via SSH supported?  
+12. **Question:** Is Docker via SSH supported?
      **Answer:** No, the Docker library used, does not support it. There is a small _but_, maybe you can get it to work via `socat`. The following URL may help you: https://serverfault.com/questions/127794/forward-local-port-or-socket-file-to-remote-socket-file/362833#362833
-13. **Question:** Can the sensors have unique entity identifiers? This is useful for renaming it in the HA GUI  
+13. **Question:** Can the sensors have unique entity identifiers? This is useful for renaming it in the HA GUI
      **Answer:** This is not possible, due to the nature of how this integration works. The docker name needs to be consistent across restart and recreate, this can be only done by overruling the entity identifier as it is working now
 
 ## Credits

--- a/custom_components/monitor_docker/__init__.py
+++ b/custom_components/monitor_docker/__init__.py
@@ -105,50 +105,6 @@ CONFIG_SCHEMA = vol.Schema(
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Will setup the Monitor Docker platform."""
 
-    # async def RunDocker(hass: HomeAssistant, entry: ConfigType) -> None:
-    #     """Wrapper around function for a separated thread."""
-    #
-    #     # Create docker instance, it will have asyncio threads
-    #     hass.data[DOMAIN][entry[CONF_NAME]] = {}
-    #     hass.data[DOMAIN][entry[CONF_NAME]][CONFIG] = entry
-    #
-    #     startCount = 0
-    #
-    #     while True:
-    #         doLoop = True
-    #
-    #         try:
-    #             hass.data[DOMAIN][entry[CONF_NAME]][API] = DockerAPI(hass, entry)
-    #             await hass.data[DOMAIN][entry[CONF_NAME]][API].init(startCount)
-    #             await hass.data[DOMAIN][entry[CONF_NAME]][API].run()
-    #             await hass.data[DOMAIN][entry[CONF_NAME]][API].load()
-    #         except Exception as err:
-    #             doLoop = False
-    #             if entry[CONF_RETRY] == 0:
-    #                 raise
-    #             else:
-    #                 _LOGGER.error("Failed Docker connect: %s", str(err))
-    #                 _LOGGER.error("Retry in %d seconds", entry[CONF_RETRY])
-    #                 await asyncio.sleep(entry[CONF_RETRY])
-    #
-    #         startCount += 1
-    #
-    #         if doLoop:
-    #             # Now run forever in this separated thread
-    #             # loop.run_forever()
-    #
-    #             # We only get here if a docker instance disconnected or HASS is stopping
-    #             if not hass.data[DOMAIN][entry[CONF_NAME]][API]._dockerStopped:
-    #                 # If HASS stopped, do not retry
-    #                 break
-
-    # Setup reload service
-    # await async_setup_reload_service(hass, DOMAIN, [DOMAIN])
-
-    # Create domain monitor_docker data variable
-    if DOMAIN not in hass.data:
-        hass.data[DOMAIN] = {}
-
     if DOMAIN not in config:
         return True  # To continue with async_setup_entry
 
@@ -181,16 +137,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             )
         )
         return True
-
-        # if entry[CONF_NAME] in hass.data[DOMAIN]:
-        #     _LOGGER.error(
-        #         "Instance %s is duplicate, please assign an unique name",
-        #         entry[CONF_NAME],
-        #     )
-        #     return False
-        #
-        # # Each docker hosts runs in its own thread. We need to pass hass too, for the load_platform
-        # asyncio.create_task(RunDocker(hass, entry))
 
     return True
 

--- a/custom_components/monitor_docker/__init__.py
+++ b/custom_components/monitor_docker/__init__.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 from datetime import timedelta
 
+from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
@@ -104,42 +105,42 @@ CONFIG_SCHEMA = vol.Schema(
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Will setup the Monitor Docker platform."""
 
-    async def RunDocker(hass: HomeAssistant, entry: ConfigType) -> None:
-        """Wrapper around function for a separated thread."""
-
-        # Create docker instance, it will have asyncio threads
-        hass.data[DOMAIN][entry[CONF_NAME]] = {}
-        hass.data[DOMAIN][entry[CONF_NAME]][CONFIG] = entry
-
-        startCount = 0
-
-        while True:
-            doLoop = True
-
-            try:
-                hass.data[DOMAIN][entry[CONF_NAME]][API] = DockerAPI(hass, entry)
-                await hass.data[DOMAIN][entry[CONF_NAME]][API].init(startCount)
-                await hass.data[DOMAIN][entry[CONF_NAME]][API].run()
-                await hass.data[DOMAIN][entry[CONF_NAME]][API].load()
-            except Exception as err:
-                doLoop = False
-                if entry[CONF_RETRY] == 0:
-                    raise
-                else:
-                    _LOGGER.error("Failed Docker connect: %s", str(err))
-                    _LOGGER.error("Retry in %d seconds", entry[CONF_RETRY])
-                    await asyncio.sleep(entry[CONF_RETRY])
-
-            startCount += 1
-
-            if doLoop:
-                # Now run forever in this separated thread
-                # loop.run_forever()
-
-                # We only get here if a docker instance disconnected or HASS is stopping
-                if not hass.data[DOMAIN][entry[CONF_NAME]][API]._dockerStopped:
-                    # If HASS stopped, do not retry
-                    break
+    # async def RunDocker(hass: HomeAssistant, entry: ConfigType) -> None:
+    #     """Wrapper around function for a separated thread."""
+    #
+    #     # Create docker instance, it will have asyncio threads
+    #     hass.data[DOMAIN][entry[CONF_NAME]] = {}
+    #     hass.data[DOMAIN][entry[CONF_NAME]][CONFIG] = entry
+    #
+    #     startCount = 0
+    #
+    #     while True:
+    #         doLoop = True
+    #
+    #         try:
+    #             hass.data[DOMAIN][entry[CONF_NAME]][API] = DockerAPI(hass, entry)
+    #             await hass.data[DOMAIN][entry[CONF_NAME]][API].init(startCount)
+    #             await hass.data[DOMAIN][entry[CONF_NAME]][API].run()
+    #             await hass.data[DOMAIN][entry[CONF_NAME]][API].load()
+    #         except Exception as err:
+    #             doLoop = False
+    #             if entry[CONF_RETRY] == 0:
+    #                 raise
+    #             else:
+    #                 _LOGGER.error("Failed Docker connect: %s", str(err))
+    #                 _LOGGER.error("Retry in %d seconds", entry[CONF_RETRY])
+    #                 await asyncio.sleep(entry[CONF_RETRY])
+    #
+    #         startCount += 1
+    #
+    #         if doLoop:
+    #             # Now run forever in this separated thread
+    #             # loop.run_forever()
+    #
+    #             # We only get here if a docker instance disconnected or HASS is stopping
+    #             if not hass.data[DOMAIN][entry[CONF_NAME]][API]._dockerStopped:
+    #                 # If HASS stopped, do not retry
+    #                 break
 
     # Setup reload service
     # await async_setup_reload_service(hass, DOMAIN, [DOMAIN])
@@ -169,15 +170,27 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 [CONTAINER_INFO_ALLINONE]
             )
 
-        if entry[CONF_NAME] in hass.data[DOMAIN]:
-            _LOGGER.error(
-                "Instance %s is duplicate, please assign an unique name",
-                entry[CONF_NAME],
+        # Convert the entry to a config_entry
+        name = entry.get(CONF_NAME)
+        _LOGGER.debug("Starting config entry flow for %s with config %s", name, entry)
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": config_entries.SOURCE_IMPORT},
+                data=entry,
             )
-            return False
+        )
+        return True
 
-        # Each docker hosts runs in its own thread. We need to pass hass too, for the load_platform
-        asyncio.create_task(RunDocker(hass, entry))
+        # if entry[CONF_NAME] in hass.data[DOMAIN]:
+        #     _LOGGER.error(
+        #         "Instance %s is duplicate, please assign an unique name",
+        #         entry[CONF_NAME],
+        #     )
+        #     return False
+        #
+        # # Each docker hosts runs in its own thread. We need to pass hass too, for the load_platform
+        # asyncio.create_task(RunDocker(hass, entry))
 
     return True
 

--- a/custom_components/monitor_docker/config_flow.py
+++ b/custom_components/monitor_docker/config_flow.py
@@ -318,6 +318,12 @@ class DockerConfigFlow(ConfigFlow, domain=DOMAIN):
             },
         )
         self._abort_if_unique_id_configured()
+        if exclude := import_info.pop(CONF_CONTAINERS_EXCLUDE, None):
+            import_info[CONF_CONTAINERS] = [
+                container
+                for container in import_info[CONF_CONTAINERS]
+                if container not in exclude
+            ]
         for key, value in import_info.items():
             if key in self.data and key not in [CONF_CONTAINERS_EXCLUDE]:
                 self.data[key] = value

--- a/custom_components/monitor_docker/config_flow.py
+++ b/custom_components/monitor_docker/config_flow.py
@@ -299,6 +299,12 @@ class DockerConfigFlow(ConfigFlow, domain=DOMAIN):
         self, import_info: Mapping[str, Any]
     ) -> ConfigFlowResult:
         """Import config from configuration.yaml."""
-        pass
         _LOGGER.debug("Starting async_step_import - %s", import_info)
-        return await self.async_step_user(import_info)
+        if import_info[CONF_URL] == "":
+            import_info[CONF_URL] = None
+        await self.async_set_unique_id(import_info[CONF_NAME])
+        self._abort_if_unique_id_configured()
+        for key, value in import_info.items():
+            if key in self.data:
+                self.data[key] = value
+        return self.async_create_entry(title=self.data[CONF_NAME], data=self.data)

--- a/custom_components/monitor_docker/config_flow.py
+++ b/custom_components/monitor_docker/config_flow.py
@@ -295,13 +295,10 @@ class DockerConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    # async def async_step_import(self, import_data) -> FlowResult:
-    #     """Import config from configuration.yaml."""
-    #     return await self.async_step_user(import_data)
-
-    # async def async_step_reauth(self, user_input: Mapping[str, Any]) -> FlowResult:
-    #     """Perform reauth upon an API authentication error."""
-    #     self._config_entry = self.hass.config_entries.async_get_entry(
-    #         self.context["entry_id"]
-    #     )
-    #     return await self.async_step_user()
+    async def async_step_import(
+        self, import_info: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Import config from configuration.yaml."""
+        pass
+        _LOGGER.debug("Starting async_step_import - %s", import_info)
+        return await self.async_step_user(import_info)

--- a/custom_components/monitor_docker/helpers.py
+++ b/custom_components/monitor_docker/helpers.py
@@ -715,6 +715,11 @@ class DockerAPI:
 
                 # Now go through all containers and get the cpu/memory stats
                 for container in self._containers.values():
+                    if container is None:
+                        _LOGGER.warning(
+                            "[%s]: run_docker_info container is not yet initilized",
+                            self._instance,
+                        )
                     try:
                         info = container.get_info()
                         if info.get(CONTAINER_INFO_STATE) == "running":

--- a/custom_components/monitor_docker/translations/en.json
+++ b/custom_components/monitor_docker/translations/en.json
@@ -75,5 +75,11 @@
             "reauth_successful": "Reauthorization successful",
             "reconfigure_successful": "Reconfiguration successful"
         }
+    },
+    "issues": {
+        "remove_configuration_yaml": {
+            "description": "Remove your settings for {domain} {integration_title} from configuration.yaml as they are now managed via the ConfigFlow UI.",
+            "title": "Manually configured {integration_title} deprecated"
+        }
     }
 }

--- a/custom_components/monitor_docker/translations/en.json
+++ b/custom_components/monitor_docker/translations/en.json
@@ -78,8 +78,8 @@
     },
     "issues": {
         "remove_configuration_yaml": {
-            "description": "Remove your settings for {domain} {integration_title} from configuration.yaml as they are now managed via the ConfigFlow UI.",
-            "title": "Manually configured {integration_title} deprecated"
+            "description": "Fist ensure that your integration settings from configuration.yaml still are intact (renaming is no longer available). Explicit settings can be viewed and changed in the Reconfigure meny for each integration istance.\nRenaming can be done on device or entiti level in UI.\nThen remove your settings for {domain} {integration_title} from configuration.yaml to get rid of this message.",
+            "title": "Manually configured {integration_title} no longer used"
         }
     }
 }


### PR DESCRIPTION
Will import settings from configuration.yaml and then render them useless (unless you manually remove the config-entry in UI and restart HA, then they will get re-imported)

You decide if this is something you want.