### PR TITLE
Add base for managing config_entry version migration

### DIFF
--- a/custom_components/monitor_docker/__init__.py
+++ b/custom_components/monitor_docker/__init__.py
@@ -14,11 +14,12 @@ from homeassistant.const import (
     CONF_URL,
     Platform,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, IntegrationError
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.reload import async_setup_reload_service
 
+from .config_flow import DockerConfigFlow
 from .const import (
     API,
     CONF_CERTPATH,
@@ -227,4 +228,90 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
 async def async_reset_platform(hass: HomeAssistant, integration_name: str) -> None:
     """Reload the integration."""
     if DOMAIN not in hass.data:
-        _LOGGER.error("monitor_docker not loaded")
+        _LOGGER.error("Monitor_docker not loaded")
+
+
+#################################################################
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate old entry."""
+    _LOGGER.debug(
+        "Attempting migrating configuration from version %s.%s",
+        entry.version,
+        entry.minor_version,
+    )
+
+    class MigrateError(IntegrationError):
+        """Error to indicate there is was an error in version migration."""
+
+    installed_version = DockerConfigFlow.VERSION
+    installed_minor_version = DockerConfigFlow.MINOR_VERSION
+
+    new_data = {**entry.data}
+    # new_options = {**entry.options}  # Note used
+
+    if entry.version > installed_version:
+        _LOGGER.warning(
+            "Downgrading major version from %s to %s is not allowed",
+            entry.version,
+            installed_version,
+        )
+        return False
+
+    if (
+        entry.version == installed_version
+        and entry.minor_version > installed_minor_version
+    ):
+        _LOGGER.warning(
+            "Downgrading minor version from %s.%s to %s.%s is not allowed",
+            entry.version,
+            entry.minor_version,
+            installed_version,
+            installed_minor_version,
+        )
+        return False
+
+    # Fake update function, just as an example
+    # def data_1_1_to_1_2(data: dict):
+    #     if entity_id := data.pop("old_certpath_format", None):
+    #         data[CONF_CERTPATH] = entity_id
+    #         return data
+    #     _LOGGER.warning('Could not find "np_entity" in entry')
+    #     raise MigrateError('Could not find "np_entity" in entry')
+
+    try:
+        if entry.version == 1:
+            pass
+            # Verison 1.1 to 1.2
+            # if entry.minor_version == 1:
+            #     new_data = data_1_1_to_1_2(new_data)
+            #     entry.minor_version = 2
+            # Version 1.2 to 2.0
+            # if entry.minor_version == 2:
+            #     new_data = data_1_2_to_2_0(new_data)
+            #     entry.minor_version = 0
+    except MigrateError as err:
+        _LOGGER.error(
+            "Error while upgrading from version %s.%s to %s.%s",
+            entry.version,
+            entry.minor_version,
+            installed_version,
+            installed_minor_version,
+        )
+        _LOGGER.error(str(err))
+        return False
+
+    hass.config_entries.async_update_entry(
+        entry,
+        data=new_data,
+        # options=new_options,
+        version=installed_version,
+        minor_version=installed_minor_version,
+    )
+    _LOGGER.info(
+        "Migration configuration from version %s.%s to %s.%s successful",
+        entry.version,
+        entry.minor_version,
+        installed_version,
+        installed_minor_version,
+    )
+    return True

--- a/custom_components/monitor_docker/__init__.py
+++ b/custom_components/monitor_docker/__init__.py
@@ -272,11 +272,11 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Fake update function, just as an example
     # def data_1_1_to_1_2(data: dict):
-    #     if entity_id := data.pop("old_certpath_format", None):
-    #         data[CONF_CERTPATH] = entity_id
+    #     OLD_CERTPATH = "old_certpath_key"
+    #     if certpath := data.pop("OLD_CERTPATH", None):
+    #         data[CONF_CERTPATH] = certpath
     #         return data
-    #     _LOGGER.warning('Could not find "np_entity" in entry')
-    #     raise MigrateError('Could not find "np_entity" in entry')
+    #     raise MigrateError(f'Could not find "{OLD_CERTPATH}" in data')
 
     try:
         if entry.version == 1:
@@ -288,7 +288,10 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             # Version 1.2 to 2.0
             # if entry.minor_version == 2:
             #     new_data = data_1_2_to_2_0(new_data)
+            #     entry.version = 2
             #     entry.minor_version = 0
+        # if entry.version == 2:
+        #     ...
     except MigrateError as err:
         _LOGGER.error(
             "Error while upgrading from version %s.%s to %s.%s",

--- a/custom_components/monitor_docker/config_flow.py
+++ b/custom_components/monitor_docker/config_flow.py
@@ -58,6 +58,7 @@ class DockerConfigFlow(ConfigFlow, domain=DOMAIN):
     """Docker config flow."""
 
     VERSION = 1
+    MINOR_VERSION = 1
     data = {
         # User
         CONF_NAME: DEFAULT_NAME,


### PR DESCRIPTION
For now no actual function as there is only one config_entry version but if in the future some config variable is added, removed or changed this functionality can upgrade the config_entry and store in new format version.

I'm pretty sure this function is only called when the stored majot & minor version in config_entry are different than the class-variables in ConfigEntry.