### PR TITLE
Fix memory calculations when "stats" is not present in "memory_stats"

### DIFF
--- a/custom_components/monitor_docker/helpers.py
+++ b/custom_components/monitor_docker/helpers.py
@@ -1145,10 +1145,11 @@ class DockerContainerAPI:
             cache = 0
             # https://docs.docker.com/engine/reference/commandline/stats/
             # Version is 19.04 or higher, don't use "cache"
-            if "total_inactive_file" in raw["memory_stats"]["stats"]:
-                cache = raw["memory_stats"]["stats"]["total_inactive_file"]
-            elif "inactive_file" in raw["memory_stats"]["stats"]:
-                cache = raw["memory_stats"]["stats"]["inactive_file"]
+            if "stats" in raw["memory_stats"]:
+                if "total_inactive_file" in raw["memory_stats"]["stats"]:
+                    cache = raw["memory_stats"]["stats"]["total_inactive_file"]
+                elif "inactive_file" in raw["memory_stats"]["stats"]:
+                    cache = raw["memory_stats"]["stats"]["inactive_file"]
 
             memory_stats["usage"] = toMB(
                 raw["memory_stats"]["usage"] - cache,


### PR DESCRIPTION
"stats" is not present in "memory_stats" when using podman instead of docker, breaking the memory calculations.
Everything else works fine.

this PR fixes https://github.com/ualex73/monitor_docker/issues/184