### PR TITLE
feat: on-demand refresh — reload service + auto-refresh on container events

### DIFF
--- a/custom_components/monitor_docker/__init__.py
+++ b/custom_components/monitor_docker/__init__.py
@@ -12,7 +12,7 @@ from homeassistant.const import (
     CONF_SCAN_INTERVAL,
     CONF_URL,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.reload import async_setup_reload_service
 
@@ -48,6 +48,7 @@ from .const import (
     DOMAIN,
     MONITORED_CONDITIONS_LIST,
     PRECISION,
+    SERVICE_RELOAD,
 )
 from .helpers import DockerAPI
 
@@ -173,6 +174,17 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
         # Each docker hosts runs in its own thread. We need to pass hass too, for the load_platform
         asyncio.create_task(RunDocker(hass, entry))
+
+    # Register an on-demand reload/refresh service. Calling it wakes every poll
+    # loop so fresh Docker data is fetched immediately instead of waiting for the
+    # next scan_interval.
+    async def async_handle_reload(call: ServiceCall) -> None:
+        for _name, data in hass.data.get(DOMAIN, {}).items():
+            api = data.get(API)
+            if api is not None:
+                api.request_refresh()
+
+    hass.services.async_register(DOMAIN, SERVICE_RELOAD, async_handle_reload)
 
     return True
 

--- a/custom_components/monitor_docker/const.py
+++ b/custom_components/monitor_docker/const.py
@@ -42,6 +42,7 @@ DEFAULT_BUTTONNAME = "{name} Restart"
 COMPONENTS = ["sensor", "switch", "button"]
 
 SERVICE_RESTART = "restart"
+SERVICE_RELOAD = "reload"
 
 PRECISION = 2
 

--- a/custom_components/monitor_docker/helpers.py
+++ b/custom_components/monitor_docker/helpers.py
@@ -106,6 +106,8 @@ class DockerAPI:
         self._dockerStopped = False
         self._subscribers: list[Callable] = []
         self._api: aiodocker.Docker = None
+        # Event used to wake the poll loops for an on-demand refresh (reload service)
+        self._refresh_event: asyncio.Event = asyncio.Event()
 
         _LOGGER.debug("[%s]: Helper version: %s", self._instance, VERSION)
 
@@ -544,6 +546,32 @@ class DockerAPI:
                                 oname,
                             )
 
+                    elif event["Action"] in (
+                        "start",
+                        "stop",
+                        "die",
+                        "kill",
+                        "oom",
+                        "pause",
+                        "unpause",
+                        "restart",
+                    ) or event["Action"].startswith("health_status"):
+                        # A container changed state or health without being added or
+                        # removed. The info/stats loops would otherwise only notice on
+                        # the next scan_interval, so trigger an immediate refresh to
+                        # update the entities and container counters right away.
+                        try:
+                            _cname = event["Actor"]["Attributes"]["name"]
+                        except (KeyError, TypeError):
+                            _cname = ""
+                        _LOGGER.debug(
+                            "[%s] %s: Event '%s' -> on-demand refresh",
+                            self._instance,
+                            _cname,
+                            event["Action"],
+                        )
+                        self.request_refresh()
+
         except Exception as err:
             exc_info = True if str(err) == "" else False
             _LOGGER.error(
@@ -809,7 +837,7 @@ class DockerAPI:
             if error:
                 await asyncio.sleep(self._retry_interval)
             else:
-                await asyncio.sleep(self._interval)
+                await self._sleep_or_refresh(self._interval)
 
     #############################################################
     def list_containers(self):
@@ -828,6 +856,27 @@ class DockerAPI:
     #############################################################
     def get_info(self) -> dict[str, Any]:
         return self._info
+
+    #############################################################
+    def request_refresh(self) -> None:
+        """Wake the info loop and every container loop to fetch immediately."""
+        _LOGGER.debug("[%s]: On-demand refresh requested", self._instance)
+        # Each loop owns its event and clears it after waking, so a request is
+        # never lost even if a loop happens to be mid-fetch when it arrives
+        # (e.g. the rapid die+start events of a container restart).
+        self._refresh_event.set()
+        for container in list(self._containers.values()):
+            container.request_refresh()
+
+    #############################################################
+    async def _sleep_or_refresh(self, seconds: int) -> None:
+        """Sleep for 'seconds', but wake early if a refresh was requested."""
+        try:
+            await asyncio.wait_for(self._refresh_event.wait(), timeout=seconds)
+        except asyncio.TimeoutError:
+            pass
+        finally:
+            self._refresh_event.clear()
 
 
 #################################################################
@@ -848,6 +897,7 @@ class DockerContainerAPI:
         self._name = cname
         self._interval: int = config[CONF_SCAN_INTERVAL].seconds
         self._retry_interval: int = config[CONF_RETRY]
+        self._refresh_event: asyncio.Event = asyncio.Event()
         self._busy = False
         self._atInit = atInit
         self._task: asyncio.Task | None = None
@@ -915,6 +965,21 @@ class DockerContainerAPI:
         self._task = asyncio.create_task(self._run())
 
         return True
+
+    #############################################################
+    def request_refresh(self) -> None:
+        """Wake this container's loop to fetch immediately."""
+        self._refresh_event.set()
+
+    #############################################################
+    async def _sleep_or_refresh(self, seconds: int) -> None:
+        """Sleep for 'seconds', but wake early if a refresh was requested."""
+        try:
+            await asyncio.wait_for(self._refresh_event.wait(), timeout=seconds)
+        except asyncio.TimeoutError:
+            pass
+        finally:
+            self._refresh_event.clear()
 
     #############################################################
     async def _run(self) -> None:
@@ -995,7 +1060,7 @@ class DockerContainerAPI:
             if error:
                 await asyncio.sleep(self._retry_interval)
             else:
-                await asyncio.sleep(self._interval)
+                await self._sleep_or_refresh(self._interval)
 
     #############################################################
     async def _run_container_info(self) -> None:

--- a/custom_components/monitor_docker/services.yaml
+++ b/custom_components/monitor_docker/services.yaml
@@ -7,3 +7,9 @@ restart:
     server:
       selector:
         text:
+reload:
+  name: Reload
+  description: >-
+    Force an immediate on-demand refresh of all monitored Docker data
+    (container state, stats and engine info) instead of waiting for the
+    next scan_interval.


### PR DESCRIPTION
## Summary

Two related improvements that make monitor_docker data update **on demand** instead of only every `scan_interval`:

1. **New `monitor_docker.reload` service** — force an immediate refresh of all monitored Docker data (container state, stats and engine info).
2. **Auto-refresh on container events** — the Docker event stream now triggers an immediate refresh on `start`/`stop`/`die`/`kill`/`pause`/`unpause`/`restart`.

## Motivation

The sensors are push-based (`should_poll=False`) and the background poll loops `await asyncio.sleep(scan_interval)` between fetches, so there was previously **no way to refresh on demand** short of restarting Home Assistant (`homeassistant.update_entity` is a no-op on these entities). Also, `_run_docker_events` only acted on create/destroy/rename and merely logged start/stop, so a plain start/stop was reflected only on the next poll.

This is useful for:
- Dashboards/automations that need up-to-date container state right after an action.
- Setups that raise `scan_interval` (to reduce recorder churn) but still want a manual "Refresh now" button and instant reaction to start/stop.

Note: the reload service registration was already stubbed out in the code (commented `async_setup_reload_service` + an empty `async_reset_platform`). This implements it via a lightweight refresh rather than a full platform reload.

## Implementation

- A shared `asyncio.Event` per `DockerAPI`, passed to each `DockerContainerAPI`. The plain interval `asyncio.sleep(self._interval)` in both the docker-info loop and each container loop is replaced by `_sleep_or_refresh()` = `asyncio.wait_for(event.wait(), timeout=interval)`.
- `request_refresh()` does `event.set()` + `event.clear()`, waking every current waiter exactly once so they fetch immediately and push fresh values to the **existing** entities (no teardown/re-add; entity IDs and history preserved).
- The `monitor_docker.reload` service calls `request_refresh()` on every configured instance.
- `_run_docker_events` now calls `request_refresh()` on container `start`/`stop`/`die`/`kill`/`pause`/`unpause`/`restart` actions.
- Retry sleeps are untouched; the container loop falls back to a plain sleep when no event is provided (backwards-compatible).

## Testing

Live Docker host (25 containers, `scan_interval: 60`, `allinone`):
- `monitor_docker.reload` appears in Developer Tools → Actions; calling it refreshes container sensors within ~1s (verified a container's CPU% changing off-cycle) vs. no change without it.
- Starting/stopping a container triggers an immediate refresh via the event stream.
- No teardown; entities and history intact; no errors in the log.
