### PR TITLE
Add unique_id to switch & button entities (UI-manageable, hideable)

### DIFF
--- a/custom_components/monitor_docker/button.py
+++ b/custom_components/monitor_docker/button.py
@@ -187,11 +187,16 @@ class DockerContainerButton(ButtonEntity):
         )
         self._name = name_format.format(name=alias_name)
         self._removed = False
+        self._attr_unique_id = slugify(f"{self._instance}_{self._cname}_restart")
 
     @property
     def entity_id(self) -> str:
         """Return the entity id of the button."""
         return self._entity_id
+
+    @entity_id.setter
+    def entity_id(self, value: str) -> None:
+        self._entity_id = value
 
     @property
     def name(self) -> str:

--- a/custom_components/monitor_docker/switch.py
+++ b/custom_components/monitor_docker/switch.py
@@ -188,11 +188,16 @@ class DockerContainerSwitch(SwitchEntity):
         )
         self._name = name_format.format(name=alias_name)
         self._removed = False
+        self._attr_unique_id = slugify(f"{self._instance}_{self._cname}_switch")
 
     @property
     def entity_id(self) -> str:
         """Return the entity id of the switch."""
         return self._entity_id
+
+    @entity_id.setter
+    def entity_id(self, value: str) -> None:
+        self._entity_id = value
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
## Summary

Docker container `switch` and `button` entities currently have **no `unique_id`**, so they never get an entity-registry entry. As a result they can't be hidden, renamed, assigned to an area, or exposed/hidden from the **Wear OS** and **Android Auto** companion apps (both filter on the entity registry). On installs with many containers this clutters those apps with restart buttons and on/off switches that can't be curated.

This adds a stable `unique_id` to both `DockerContainerSwitch` and `DockerContainerButton`:

```
{instance}_{container}_switch      # switch
{instance}_{container}_restart     # button
```

## Why the `entity_id` setter is also needed

Both classes override `entity_id` with a **read-only property**. Once an entity has a `unique_id`, Home Assistant's entity platform registers it and then assigns `entity.entity_id = entry.entity_id`, which raises `AttributeError` on a read-only property and leaves the entity **unavailable**. Adding an `entity_id` setter fixes this.

Because the registry derives `suggested_object_id` from the entity's existing `entity_id`, **existing entity_ids are preserved** — no dashboards/automations break on upgrade (verified on a live install: 26 switches + 27 buttons re-registered with identical entity_ids, 0 renamed).

## Changes
- `switch.py`: `_attr_unique_id` + `entity_id` setter on `DockerContainerSwitch`
- `button.py`: `_attr_unique_id` + `entity_id` setter on `DockerContainerButton`

## Testing
Live install (HA 2026.7): after restart all switch/button entities register with a unique_id, are available with correct state, gain UI management (rename/area/hide/expose), and keep their original entity_ids. Sensors (already unique-id-less) are untouched.
